### PR TITLE
no more mixed content maybe

### DIFF
--- a/editProfile.php
+++ b/editProfile.php
@@ -37,7 +37,7 @@
     <link rel="stylesheet" type="text/css" href="css/editProfile.css">
     
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
     <script src="js/loader.js"></script>
     <script src="js/profile/uploadSkin.js"></script>
     <script src="js/profile/modal.js"></script>

--- a/editProfileold.php
+++ b/editProfileold.php
@@ -31,7 +31,7 @@
     <link rel="stylesheet" type="text/css" href="bulma/css/bulma.css">
     <link rel="stylesheet" type="text/css" href="css/editProfile.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
     <script src="js/loader.js"></script>
     <script src="js/profile/uploadSkin.js"></script>
     <script src="js/profile/modal.js"></script>

--- a/faq.php
+++ b/faq.php
@@ -15,7 +15,7 @@
     <link rel="stylesheet" type="text/css" href="css/loader.css">
     <link rel="icon" type="image/png" href="images/icon.png" />
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
     <script src="js/loader.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <!-- Cookie bar -->

--- a/forgotPassword.php
+++ b/forgotPassword.php
@@ -107,7 +107,7 @@ function exitPage(){
     <link rel="icon" type="image/png" href="images/icon.png" />
     <script type="text/javascript" src="js/index/upload.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
     <script src="js/loader.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <!-- Cookie bar -->

--- a/js/loader.js
+++ b/js/loader.js
@@ -1,6 +1,6 @@
 //Copy paste this
 //<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-//<script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
+//<script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
 //<script src="js/loader.js"></script>
 //after <body>
 //<div class="loader"></div>

--- a/login.php
+++ b/login.php
@@ -27,7 +27,7 @@
   <link rel="stylesheet" type="text/css" href="css/footer.css">
   <link rel="stylesheet" type="text/css" href="css/loader.css">
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
   <script src="js/loader.js"></script>
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <!-- Cookie bar -->

--- a/progress.php
+++ b/progress.php
@@ -62,7 +62,7 @@ session_start();
     <link rel="icon" type="image/png" href="images/icon.png" />
     <script type="text/javascript" src="js/index/upload.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
     <script src="js/loader.js"></script>
     <script src="js/progress/autoUpload.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/register.php
+++ b/register.php
@@ -164,7 +164,7 @@ if(isFormSubmitted()){
      <link rel="stylesheet" type="text/css" href="css/loader.css">
 
      <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-     <script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
+     <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
      <script src="js/loader.js"></script>
      <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
      <script src='https://www.google.com/recaptcha/api.js'></script>

--- a/search.php
+++ b/search.php
@@ -71,7 +71,7 @@
 		<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
 		<script src="js/loader.js"></script>
 	</head>
 

--- a/userVerification.php
+++ b/userVerification.php
@@ -129,7 +129,7 @@ if(empty($verfUserId)){
     <link rel="stylesheet" type="text/css" href="css/footer.css">
     <link rel="stylesheet" type="text/css" href="css/loader.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
     <script src="js/loader.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <!-- Cookie bar -->

--- a/view.php
+++ b/view.php
@@ -95,7 +95,7 @@
     <link rel="stylesheet" type="text/css" href="css/loader.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
     <script src="js/loader.js"></script>
     <script src="js/view/modal.js"></script>
 


### PR DESCRIPTION
Not a huge issue, but wanted to see if I could fix the mixed content warnings on Chrome by linking to https JS libraries. Untested, but should work.

This PR removes refs to cloudflare http links and replaces with https links to avoid mixed content issues in Chrome.

![screenshot from 2019-01-24 10-56-45](https://user-images.githubusercontent.com/1891697/51694667-ee174980-1fc6-11e9-96f2-62141a588da2.png)
